### PR TITLE
[feat] Implements county click functionality on map interface /12

### DIFF
--- a/app/javascript/packs/state_map_utils.js
+++ b/app/javascript/packs/state_map_utils.js
@@ -63,8 +63,8 @@ exports.setupEventHandlers = (stateMap) => {
         return `${countyName}, ${stateMap.state.symbol}`;
     };
     const clickCallback = (elem) => {
-        const countyFipsCode = elem.attr('data-county-fips-code');
-        window.location.href = `/state/${stateMap.state.symbol}/county/${countyFipsCode}`;
+        const countyName = elem.attr('data-county-name');
+        window.location.href = `/search?address=${countyName.replace(/ /g, '+') + "%2C+" + stateMap.state.name}&commit=Search`;
     };
     mapUtils.handleMapMouseEvents(targets, hoverHtmlProvider, clickCallback);
 };


### PR DESCRIPTION
- Enables users to click on counties displayed on the map. 
- When a county is clicked, the user is redirected to the search#search route with appropriate query parameters (county name, state name).