### PR TITLE
[feat] Implements ProPublica campaign finance API

### DIFF
--- a/app/controllers/campaign_finances_controller.rb
+++ b/app/controllers/campaign_finances_controller.rb
@@ -1,0 +1,22 @@
+class CampaignFinancesController < ApplicationController
+  def index
+    @election_cycle_options = (2010..2020).map { |year| [year.to_s, year] }
+    categories = [
+      'Candidate Loan',
+      'Contribution Total',
+      'Debts Owed',
+      'Disbursements Total',
+      'End Cash',
+      'Individual Total',
+      'PAC Total',
+      'Receipts Total',
+      'Refund Total'
+    ]
+    @category_options = categories.map { |category| [category, category] }
+  end
+
+  def search
+    @candidates = CampaignFinance.top_candidates(params[:cycle], params[:category])
+    render :show
+  end
+end

--- a/app/models/campaign_finance.rb
+++ b/app/models/campaign_finance.rb
@@ -1,0 +1,29 @@
+require 'net/http'
+require 'json'
+
+class CampaignFinance
+  API_BASE_URL = 'https://api.propublica.org/campaign-finance/v1/'
+  API_KEY = '9lcjslvwVjbqtX0KcQQ3W9rFm316caQQ2T89n4xA'
+
+  def self.top_candidates(cycle, category)
+    category = category.downcase.gsub(' ', '-')
+    url = URI("#{API_BASE_URL}#{cycle}/candidates/leaders/#{category}.json")
+
+    request = Net::HTTP::Get.new(url)
+    request['X-API-Key'] = API_KEY
+    response = Net::HTTP.start(url.hostname, url.port, use_ssl: url.scheme == 'https') do |http|
+      http.request(request)
+    end
+
+    data = JSON.parse(response.body)
+    candidates = data['results'].map do |candidate|
+      {
+        name: candidate['name'],
+        party: candidate['party'],
+        state: candidate['state'] ? candidate['state'].split('/')[2].gsub('.json', '') : nil
+      }
+    end
+
+    candidates
+  end
+end

--- a/app/views/campaign_finances/index.html.haml
+++ b/app/views/campaign_finances/index.html.haml
@@ -1,0 +1,22 @@
+.row.mt-2
+  .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
+    %h1.text-center Campaign Finances
+
+  .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
+    = form_tag search_campaign_finances_path, method: :get do
+      .form-group.row
+        .col-md-4
+          %label.col-form-label
+            Election cycle:
+        .col-md-6
+          = select_tag :cycle, options_for_select(@election_cycle_options), class: 'form-control'
+
+      .form-group.row
+        .col-md-4
+          %label.col-form-label
+            Category:
+        .col-md-6
+          = select_tag :category, options_for_select(@category_options), class: 'form-control'
+
+      .actions
+        = submit_tag 'Search', id: 'search_campaign_finances', class: 'btn btn-primary'

--- a/app/views/campaign_finances/show.html.haml
+++ b/app/views/campaign_finances/show.html.haml
@@ -1,0 +1,19 @@
+.container-fluid
+    .row
+        .col-md-8.offset-md-2
+            .table-responsive-md.pt-5
+                %table.table.table-striped.table-hover#events
+                    %caption Table of Representatives
+                    %thead.thead-dark
+                        %tr
+                            %th #
+                            %th Name
+                            %th Party
+                            %th State
+                    %tbody
+                        - @candidates.each_with_index do |candidate, index|
+                            %tr
+                                %td= index + 1  # Adding 1 since index starts from 0
+                                %td= candidate[:name]
+                                %td= candidate[:party]
+                                %td= candidate[:state]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,4 +45,8 @@ Rails.application.routes.draw do
             :as                                                    => :articles_my_news_item
     end
     get '/search/(:address)' => 'search#search', :as => 'search_representatives'
+    
+    resources :campaign_finances, only: [:index] do
+        get :search, on: :collection
+    end
 end


### PR DESCRIPTION
- New model, controller, and corresponding set of views to handle Campaign Finance information
- Constructs a Campaign Finances search page containing two dropdown menus, one for each parameter (cycle and category) required by the ProPublica API
- Restricts dropdown options based on the valid selections allowed by the ProPublica API
- Implements a "Search" button to initiate the query based on the selected parameters
- Renders a table presenting the top 20 candidates matching the chosen category and election cycle